### PR TITLE
Unroll MIN as the straight ?: construct

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -242,7 +242,7 @@ void gh_buf_attach(gh_buf *buf, char *ptr, size_t asize)
 
 int gh_buf_cmp(const gh_buf *a, const gh_buf *b)
 {
-	int result = memcmp(a->ptr, b->ptr, MIN(a->size, b->size));
+	int result = memcmp(a->ptr, b->ptr, a->size < b->size ? a->size : b-> size);
 	return (result != 0) ? result :
 		(a->size < b->size) ? -1 : (a->size > b->size) ? 1 : 0;
 }


### PR DESCRIPTION
Considering that not all compilers give us MIN implicitly, and since it's only at one place in the code, losing the MIN shouldn't be too high a price to pay, readability-wise, for portability.
