### PR TITLE
Implement `url_component` escaping/unescaping

### DIFF
--- a/houdini.h
+++ b/houdini.h
@@ -30,11 +30,11 @@ extern int houdini_escape_html0(gh_buf *ob, const uint8_t *src, size_t size, int
 extern int houdini_unescape_html(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_xml(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_uri(gh_buf *ob, const uint8_t *src, size_t size);
-extern int houdini_escape_url_component(gh_buf *ob, const uint8_t *src, size_t size);
+extern int houdini_escape_uri_component(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_url(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_href(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_uri(gh_buf *ob, const uint8_t *src, size_t size);
-extern int houdini_unescape_url_component(gh_buf *ob, const uint8_t *src, size_t size);
+extern int houdini_unescape_uri_component(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_url(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_js(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_js(gh_buf *ob, const uint8_t *src, size_t size);

--- a/houdini.h
+++ b/houdini.h
@@ -30,9 +30,11 @@ extern int houdini_escape_html0(gh_buf *ob, const uint8_t *src, size_t size, int
 extern int houdini_unescape_html(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_xml(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_uri(gh_buf *ob, const uint8_t *src, size_t size);
+extern int houdini_escape_url_component(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_url(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_href(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_uri(gh_buf *ob, const uint8_t *src, size_t size);
+extern int houdini_unescape_url_component(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_url(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_escape_js(gh_buf *ob, const uint8_t *src, size_t size);
 extern int houdini_unescape_js(gh_buf *ob, const uint8_t *src, size_t size);

--- a/houdini_uri_e.c
+++ b/houdini_uri_e.c
@@ -43,10 +43,10 @@ static const char URI_SAFE[] = {
 };
 
 static int
-escape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
+escape(gh_buf *ob, const uint8_t *src, size_t size,
+	const char *safe_table, bool escape_plus)
 {
 	static const uint8_t hex_chars[] = "0123456789ABCDEF";
-	const char *safe_table = is_url ? URL_SAFE : URI_SAFE;
 
 	size_t  i = 0, org;
 	uint8_t hex_str[3];
@@ -73,7 +73,7 @@ escape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 		if (i >= size)
 			break;
 
-		if (src[i] == ' ' && is_url) {
+		if (src[i] == ' ' && escape_plus) {
 			gh_buf_putc(ob, '+');
 		} else {
 			hex_str[1] = hex_chars[(src[i] >> 4) & 0xF];
@@ -90,12 +90,18 @@ escape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 int
 houdini_escape_uri(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return escape(ob, src, size, 0);
+	return escape(ob, src, size, URI_SAFE, false);
+}
+
+int
+houdini_escape_url_component(gh_buf *ob, const uint8_t *src, size_t size)
+{
+	return escape(ob, src, size, URL_SAFE, false);
 }
 
 int
 houdini_escape_url(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return escape(ob, src, size, 1);
+	return escape(ob, src, size, URL_SAFE, true);
 }
 

--- a/houdini_uri_e.c
+++ b/houdini_uri_e.c
@@ -94,7 +94,7 @@ houdini_escape_uri(gh_buf *ob, const uint8_t *src, size_t size)
 }
 
 int
-houdini_escape_url_component(gh_buf *ob, const uint8_t *src, size_t size)
+houdini_escape_uri_component(gh_buf *ob, const uint8_t *src, size_t size)
 {
 	return escape(ob, src, size, URL_SAFE, false);
 }

--- a/houdini_uri_u.c
+++ b/houdini_uri_u.c
@@ -55,7 +55,7 @@ houdini_unescape_uri(gh_buf *ob, const uint8_t *src, size_t size)
 }
 
 int
-houdini_unescape_url_component(gh_buf *ob, const uint8_t *src, size_t size)
+houdini_unescape_uri_component(gh_buf *ob, const uint8_t *src, size_t size)
 {
 	return unescape(ob, src, size, false);
 }

--- a/houdini_uri_u.c
+++ b/houdini_uri_u.c
@@ -7,18 +7,18 @@
 #define hex2c(c) ((c | 32) % 39 - 9)
 
 static int
-unescape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
+unescape(gh_buf *ob, const uint8_t *src, size_t size, bool unescape_plus)
 {
 	size_t  i = 0, org;
 
 	while (i < size) {
 		org = i;
-		while (i < size && src[i] != '%')
+		while (i < size && src[i] != '%' && src[i] != '+')
 			i++;
 
 		if (likely(i > org)) {
 			if (unlikely(org == 0)) {
-				if (i >= size && !is_url)
+				if (i >= size)
 					return 0;
 
 				gh_buf_grow(ob, HOUDINI_UNESCAPED_SIZE(size));
@@ -31,7 +31,10 @@ unescape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 		if (i >= size)
 			break;
 
-		i++;
+		if (src[i++] == '+') {
+			gh_buf_putc(ob, unescape_plus ? ' ' : '+');
+			continue;
+		}
 
 		if (i + 1 < size && _isxdigit(src[i]) && _isxdigit(src[i + 1])) {
 			unsigned char new_char = (hex2c(src[i]) << 4) + hex2c(src[i + 1]);
@@ -42,24 +45,24 @@ unescape(gh_buf *ob, const uint8_t *src, size_t size, int is_url)
 		}
 	}
 
-	if (is_url) {
-		char *find = (char *)gh_buf_cstr(ob);
-		while ((find = strchr(find, '+')) != NULL)
-			*find = ' ';
-	}
-
 	return 1;
 }
 
 int
 houdini_unescape_uri(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return unescape(ob, src, size, 0);
+	return unescape(ob, src, size, false);
+}
+
+int
+houdini_unescape_url_component(gh_buf *ob, const uint8_t *src, size_t size)
+{
+	return unescape(ob, src, size, false);
 }
 
 int
 houdini_unescape_url(gh_buf *ob, const uint8_t *src, size_t size)
 {
-	return unescape(ob, src, size, 1);
+	return unescape(ob, src, size, true);
 }
 


### PR DESCRIPTION
As requested by @ptoomey3:
- during `unescape_url` you should substitute `+` for space before you do any percent decoding. Doing it after makes it such that a percent encoded plus (`%2b`) is first decoded to a `+`, but then that is translated to a space. In the end, the current code makes it so that a `+` can never end up in unescaped output. 
- add a new function `escape_uri_component`. This works exactly the same as `escape_url`, but encodes space as `%20` instead of `+`. I guess technically we also need an `unescape_uri_component`, though I think the implementation will be exactly the same as `unescape_uri`. 

I think this has the functionality you wanted.
